### PR TITLE
Correct client upload in blocking mode

### DIFF
--- a/FTPClient.cpp
+++ b/FTPClient.cpp
@@ -19,9 +19,9 @@ const FTPClient::Status &FTPClient::transfer(const String &localFileName, const 
     _remoteFileName = remoteFileName;
     _direction = direction;
 
-    if (direction & FTP_GET)
+    if (direction & FTP_GET_NONBLOCKING)
       file = THEFS.open(localFileName, "w");
-    else if (direction & FTP_PUT)
+    else if (direction & FTP_PUT_NONBLOCKING)
       file = THEFS.open(localFileName, "r");
 
     if (!file)


### PR DESCRIPTION
Client upload with TransferType=FTP_PUT cleared the local file content. It first opened the file in write mode, because (direction & FTP_GET) gives TRUE in this case also.  As a result blocking mode always uploaded a 0 length file and cleared the local file.