### PR TITLE
Fix Compile problem on ESPHome

### DIFF
--- a/FTPClient.cpp
+++ b/FTPClient.cpp
@@ -19,9 +19,9 @@ const FTPClient::Status &FTPClient::transfer(const String &localFileName, const 
     _remoteFileName = remoteFileName;
     _direction = direction;
 
-    if (direction & FTP_GET)
+    if (direction & FTP_GET_NONBLOCKING)
       file = THEFS.open(localFileName, "w");
-    else if (direction & FTP_PUT)
+    else if (direction & FTP_PUT_NONBLOCKING)
       file = THEFS.open(localFileName, "r");
 
     if (!file)

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -127,7 +127,7 @@ protected:
     bool parseDataIpPort(const char *p);
 
     uint32_t sTimeOutMs; // disconnect timeout
-    oneShotMs aTimeout;  // timeout from esp8266 core library
+    oneShotFastMs aTimeout;  // timeout from esp8266 core library
 
     bool doFiletoNetwork();
     bool doNetworkToFile();

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-using esp8266::polledTimeout::oneShotFastMs; // import the type to the local namespace
+using polledTimeout::oneShotFastMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using esp32::polledTimeout::oneShotFastMs;
+using polledTimeout::oneShotFastMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -7,7 +7,7 @@
 #include <WString.h>
 
 #ifdef ESP8266
-#include <PolledTimeout.h>
+#include "esp8266compat/PolledTimeout.h"
 using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-using arduino::esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
+using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using arduino::esp8266::polledTimeout::oneShotMs;
+using esp8266::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include "esp8266compat/PolledTimeout.h"
-using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
+using esp8266Pool::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using esp32::polledTimeout::oneShotMs;
+using esp32Pool::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-using polledTimeout::oneShotFastMs; // import the type to the local namespace
+using arduino::esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using polledTimeout::oneShotFastMs;
+using arduino::esp8266::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif
@@ -127,7 +127,7 @@ protected:
     bool parseDataIpPort(const char *p);
 
     uint32_t sTimeOutMs; // disconnect timeout
-    oneShotFastMs aTimeout;  // timeout from esp8266 core library
+    oneShotMs aTimeout;  // timeout from esp8266 core library
 
     bool doFiletoNetwork();
     bool doNetworkToFile();

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
+using esp8266::polledTimeout::oneShotFastMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using esp32::polledTimeout::oneShotMs;
+using esp32::polledTimeout::oneShotFastMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
+// using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using esp32::polledTimeout::oneShotMs;
+// using esp32::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-using polledTimeout::oneShotMs; // import the type to the local namespace
+using esphome::esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-// using polledTimeout::oneShotMs;
+using esphome::esp32::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -13,7 +13,7 @@ using esp8266::polledTimeout::oneShotMs; // import the type to the local namespa
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using esp8266::polledTimeout::oneShotMs;
+using esp32::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
- using ESP8266::polledTimeout::oneShotMs; // import the type to the local namespace
+using polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
- using ESP32::polledTimeout::oneShotMs;
+// using polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-// using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
+ using ESP8266::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-// using esp32::polledTimeout::oneShotMs;
+ using ESP32::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPCommon.h
+++ b/FTPCommon.h
@@ -8,12 +8,12 @@
 
 #ifdef ESP8266
 #include <PolledTimeout.h>
-using esphome::esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
+using esp8266::polledTimeout::oneShotMs; // import the type to the local namespace
 #define BUFFERSIZE TCP_MSS
 #define PRINTu32 "lu"
 #elif defined ESP32
 #include "esp32compat/PolledTimeout.h"
-using esphome::esp32::polledTimeout::oneShotMs;
+using esp32::polledTimeout::oneShotMs;
 #define BUFFERSIZE CONFIG_TCP_MSS
 #define PRINTu32 "u"
 #endif

--- a/FTPServer.cpp
+++ b/FTPServer.cpp
@@ -46,11 +46,10 @@ FTPServer::FTPServer(FS &_FSImplementation) : FTPCommon(_FSImplementation)
   aTimeout.resetToNeverExpires();
 }
 
-void FTPServer::begin(const String &uname, const String &pword, boolean _bUnixLst)
+void FTPServer::begin(const String &uname, const String &pword)
 {
   _FTP_USER = uname;
   _FTP_PASS = pword;
-  bUnixLst = _bUnixLst;
 
   iniVariables();
 
@@ -563,8 +562,11 @@ int8_t FTPServer::processCommand()
         uint32_t fs = file.size();
         String fileTime = makeDateTimeStr(file.getLastWrite());
         file.close();
-        if (cwd == FPSTR(aSlash) && fn[0] == '/')
-          fn.remove(0, 1);
+        dashPos = fn.lastIndexOf(F("/"));
+        if (dashPos >= 0)
+        {
+          fn.remove(0, dashPos + 1);
+        }
 
         if (FTP_CMD(LIST) == command)
         {

--- a/FTPServer.cpp
+++ b/FTPServer.cpp
@@ -46,10 +46,11 @@ FTPServer::FTPServer(FS &_FSImplementation) : FTPCommon(_FSImplementation)
   aTimeout.resetToNeverExpires();
 }
 
-void FTPServer::begin(const String &uname, const String &pword)
+void FTPServer::begin(const String &uname, const String &pword, boolean _bUnixLst)
 {
   _FTP_USER = uname;
   _FTP_PASS = pword;
+  bUnixLst = _bUnixLst;
 
   iniVariables();
 

--- a/esp32compat/PolledTimeout.h
+++ b/esp32compat/PolledTimeout.h
@@ -27,7 +27,7 @@
 
 #include <Arduino.h>
 
-namespace esp32
+namespace ESP32
 {
 
 

--- a/esp32compat/PolledTimeout.h
+++ b/esp32compat/PolledTimeout.h
@@ -27,7 +27,7 @@
 
 #include <Arduino.h>
 
-namespace ESP32
+namespace esp32Pool
 {
 
 

--- a/esp8266compat/PolledTimeout.h
+++ b/esp8266compat/PolledTimeout.h
@@ -1,0 +1,289 @@
+#ifndef __POLLEDTIMING_H__
+#define __POLLEDTIMING_H__
+
+
+/*
+ PolledTimeout.h - Encapsulation of a polled Timeout
+ 
+ Copyright (c) 2018 Daniel Salazar. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <limits>
+
+#include <Arduino.h>
+
+namespace ESP8266
+{
+
+
+namespace polledTimeout
+{
+
+namespace YieldPolicy
+{
+
+struct DoNothing
+{
+  static void execute() {}
+};
+
+struct YieldOrSkip
+{
+  static void execute() {delay(0);}
+};
+
+template <unsigned long delayMs>
+struct YieldAndDelayMs
+{
+  static void execute() {delay(delayMs);}
+};
+
+} //YieldPolicy
+
+namespace TimePolicy
+{
+
+struct TimeSourceMillis
+{
+  // time policy in milli-seconds based on millis()
+
+  using timeType = decltype(millis());
+  static timeType time() {return millis();}
+  static constexpr timeType ticksPerSecond    = 1000;
+  static constexpr timeType ticksPerSecondMax = 1000;
+};
+
+struct TimeSourceCycles
+{
+  // time policy based on ESP.getCycleCount()
+  // this particular time measurement is intended to be called very often
+  // (every loop, every yield)
+
+  using timeType = decltype(ESP.getCycleCount());
+  static timeType time() {return ESP.getCycleCount();}
+  static constexpr timeType ticksPerSecond    = F_CPU;     // 80'000'000 or 160'000'000 Hz
+  static constexpr timeType ticksPerSecondMax = 160000000; // 160MHz
+};
+
+template <typename TimeSourceType, unsigned long long second_th>
+    // "second_th" units of timeType for one second
+struct TimeUnit
+{
+  using timeType = typename TimeSourceType::timeType;
+
+#if __GNUC__ < 5
+  // gcc-4.8 cannot compile the constexpr-only version of this function
+  // using #defines instead luckily works
+  static constexpr timeType computeRangeCompensation ()
+  {
+    #define number_of_secondTh_in_one_tick ((1.0 * second_th) / ticksPerSecond)
+    #define fractional (number_of_secondTh_in_one_tick - (long)number_of_secondTh_in_one_tick)
+
+    return ({
+      fractional == 0?
+        1: // no need for compensation
+        (number_of_secondTh_in_one_tick / fractional) + 0.5; // scalar multiplier allowing exact division
+    });
+
+    #undef number_of_secondTh_in_one_tick
+    #undef fractional
+  }
+#else
+  static constexpr timeType computeRangeCompensation ()
+  {
+    return ({
+      constexpr double number_of_secondTh_in_one_tick = (1.0 * second_th) / ticksPerSecond;
+      constexpr double fractional = number_of_secondTh_in_one_tick - (long)number_of_secondTh_in_one_tick;
+      fractional == 0?
+        1: // no need for compensation
+        (number_of_secondTh_in_one_tick / fractional) + 0.5; // scalar multiplier allowing exact division
+    });
+  }
+#endif
+
+  static constexpr timeType ticksPerSecond         = TimeSourceType::ticksPerSecond;
+  static constexpr timeType ticksPerSecondMax      = TimeSourceType::ticksPerSecondMax;
+  static constexpr timeType rangeCompensate        = computeRangeCompensation();
+  static constexpr timeType user2UnitMultiplierMax = (ticksPerSecondMax * rangeCompensate) / second_th;
+  static constexpr timeType user2UnitMultiplier    = (ticksPerSecond    * rangeCompensate) / second_th;
+  static constexpr timeType user2UnitDivider       = rangeCompensate;
+  // std::numeric_limits<timeType>::max() is reserved
+  static constexpr timeType timeMax                = (std::numeric_limits<timeType>::max() - 1) / user2UnitMultiplierMax;
+
+  static timeType toTimeTypeUnit (const timeType userUnit) {return (userUnit * user2UnitMultiplier) / user2UnitDivider;}
+  static timeType toUserUnit (const timeType internalUnit) {return (internalUnit * user2UnitDivider) / user2UnitMultiplier;}
+  static timeType time () {return TimeSourceType::time();}
+};
+
+using TimeMillis     = TimeUnit< TimeSourceMillis,       1000 >;
+using TimeFastMillis = TimeUnit< TimeSourceCycles,       1000 >;
+using TimeFastMicros = TimeUnit< TimeSourceCycles,    1000000 >;
+using TimeFastNanos  = TimeUnit< TimeSourceCycles, 1000000000 >;
+
+} //TimePolicy
+
+template <bool PeriodicT, typename YieldPolicyT = YieldPolicy::DoNothing, typename TimePolicyT = TimePolicy::TimeMillis>
+class timeoutTemplate
+{
+public:
+  using timeType = typename TimePolicyT::timeType;
+  static_assert(std::is_unsigned<timeType>::value == true, "timeType must be unsigned");
+
+  static constexpr timeType alwaysExpired   = 0;
+  static constexpr timeType neverExpires    = std::numeric_limits<timeType>::max();
+  static constexpr timeType rangeCompensate = TimePolicyT::rangeCompensate; //debug
+
+  timeoutTemplate(const timeType userTimeout)
+  {
+    reset(userTimeout);
+  }
+
+  IRAM_ATTR // fast
+  bool expired()
+  {
+    YieldPolicyT::execute(); //in case of DoNothing: gets optimized away
+    if(PeriodicT)           //in case of false: gets optimized away
+      return expiredRetrigger();
+    return expiredOneShot();
+  }
+  
+  IRAM_ATTR // fast
+  operator bool()
+  {
+    return expired(); 
+  }
+  
+  bool canExpire () const
+  {
+    return !_neverExpires;
+  }
+
+  bool canWait () const
+  {
+    return _timeout != alwaysExpired;
+  }
+
+  IRAM_ATTR // called from ISR
+  void reset(const timeType newUserTimeout)
+  {
+    reset();
+    _timeout = TimePolicyT::toTimeTypeUnit(newUserTimeout);
+    _neverExpires = (newUserTimeout < 0) || (newUserTimeout > timeMax());
+  }
+
+  IRAM_ATTR // called from ISR
+  void reset()
+  {
+    _start = TimePolicyT::time();
+  }
+
+  void resetToNeverExpires ()
+  {
+    _timeout = alwaysExpired + 1; // because canWait() has precedence
+    _neverExpires = true;
+  }
+
+  timeType getTimeout() const
+  {
+    return TimePolicyT::toUserUnit(_timeout);
+  }
+  
+  static constexpr timeType timeMax()
+  {
+    return TimePolicyT::timeMax;
+  }
+
+private:
+
+  IRAM_ATTR // fast
+  bool checkExpired(const timeType internalUnit) const
+  {
+    // canWait() is not checked here
+    // returns "can expire" and "time expired"
+    return (!_neverExpires) && ((internalUnit - _start) >= _timeout);
+  }
+
+protected:
+
+  IRAM_ATTR // fast
+  bool expiredRetrigger()
+  {
+    if (!canWait())
+      return true;
+
+    timeType current = TimePolicyT::time();
+    if(checkExpired(current))
+    {
+      unsigned long n = (current - _start) / _timeout; //how many _timeouts periods have elapsed, will usually be 1 (current - _start >= _timeout)
+      _start += n  * _timeout;
+      return true;
+    }
+    return false;
+  }
+  
+  IRAM_ATTR // fast
+  bool expiredOneShot() const
+  {
+    // returns "always expired" or "has expired"
+    return !canWait() || checkExpired(TimePolicyT::time());
+  }
+  
+  timeType _timeout;
+  timeType _start;
+  bool _neverExpires;
+};
+
+// legacy type names, deprecated (unit is milliseconds)
+
+using oneShot = polledTimeout::timeoutTemplate<false> /*__attribute__((deprecated("use oneShotMs")))*/;
+using periodic = polledTimeout::timeoutTemplate<true> /*__attribute__((deprecated("use periodicMs")))*/;
+
+// standard versions (based on millis())
+// timeMax() is 49.7 days ((2^32)-2 ms)
+
+using oneShotMs = polledTimeout::timeoutTemplate<false>;
+using periodicMs = polledTimeout::timeoutTemplate<true>;
+
+// Time policy based on ESP.getCycleCount(), and intended to be called very often:
+// "Fast" versions sacrifices time range for improved precision and reduced execution time (by 86%)
+// (cpu cycles for ::expired(): 372 (millis()) vs 52 (ESP.getCycleCount()))
+// timeMax() values:
+// Ms: max is 26843       ms (26.8  s)
+// Us: max is 26843545    us (26.8  s)
+// Ns: max is  1073741823 ns ( 1.07 s)
+// (time policy based on ESP.getCycleCount() is intended to be called very often)
+
+using oneShotFastMs = polledTimeout::timeoutTemplate<false, YieldPolicy::DoNothing, TimePolicy::TimeFastMillis>;
+using periodicFastMs = polledTimeout::timeoutTemplate<true, YieldPolicy::DoNothing, TimePolicy::TimeFastMillis>;
+using oneShotFastUs = polledTimeout::timeoutTemplate<false, YieldPolicy::DoNothing, TimePolicy::TimeFastMicros>;
+using periodicFastUs = polledTimeout::timeoutTemplate<true, YieldPolicy::DoNothing, TimePolicy::TimeFastMicros>;
+using oneShotFastNs = polledTimeout::timeoutTemplate<false, YieldPolicy::DoNothing, TimePolicy::TimeFastNanos>;
+using periodicFastNs = polledTimeout::timeoutTemplate<true, YieldPolicy::DoNothing, TimePolicy::TimeFastNanos>;
+
+} //polledTimeout
+
+
+/* A 1-shot timeout that auto-yields when in CONT can be built as follows:
+ * using oneShotYieldMs = esp8266::polledTimeout::timeoutTemplate<false, esp8266::polledTimeout::YieldPolicy::YieldOrSkip>;
+ *
+ * Other policies can be implemented by the user, e.g.: simple yield that panics in SYS, and the polledTimeout types built as needed as shown above, without modifying this file.
+ */
+
+}//esp8266
+
+#endif

--- a/esp8266compat/PolledTimeout.h
+++ b/esp8266compat/PolledTimeout.h
@@ -27,7 +27,7 @@
 
 #include <Arduino.h>
 
-namespace esp8266
+namespace esp8266Pool
 {
 
 

--- a/esp8266compat/PolledTimeout.h
+++ b/esp8266compat/PolledTimeout.h
@@ -27,7 +27,7 @@
 
 #include <Arduino.h>
 
-namespace ESP8266
+namespace esp8266
 {
 
 


### PR DESCRIPTION
ESPHome uses the esp8266 namespace for its internal components. I added PolledTimeout.h from the arduino framework for esp8266 by changing the namespace name to "esp8266pool", which fixed the problem during compilation. Similarly changed the namespace for esp32.