### PR TITLE
Fixed Compile problem on Arduino

### DIFF
--- a/esp32compat/PolledTimeout.h
+++ b/esp32compat/PolledTimeout.h
@@ -1,5 +1,4 @@
-#ifndef __POLLEDTIMING_H__
-#define __POLLEDTIMING_H__
+#pragma once
 
 
 /*
@@ -251,4 +250,3 @@ using periodicMs = polledTimeout::timeoutTemplate<true>;
 
 }//esp32
 
-#endif

--- a/esp8266compat/PolledTimeout.h
+++ b/esp8266compat/PolledTimeout.h
@@ -1,5 +1,4 @@
-#ifndef __POLLEDTIMING_H__
-#define __POLLEDTIMING_H__
+#pragma once
 
 
 /*
@@ -286,4 +285,3 @@ using periodicFastNs = polledTimeout::timeoutTemplate<true, YieldPolicy::DoNothi
 
 }//esp8266
 
-#endif


### PR DESCRIPTION
Changed include guard to #pragma once in PolledTimeout.h

FTPCommon.h was not compiling because __POLLEDTIMING_H__ was already declared in the ESP8266 Core (version 3.0.2).

FTPCommon.h is using the namespace "esp8266Pool," which is just "esp8266" in the core library. 
Instead of renaming the namespace and trying to include the core header, I thought it would be better to just change the include guard.