### PR TITLE
fix building for esp32 core 2.0.8

### DIFF
--- a/FTPClient.cpp
+++ b/FTPClient.cpp
@@ -220,7 +220,7 @@ int8_t FTPClient::controlConnect()
   return -1;
 }
 
-bool FTPClient::waitFor(const int16_t respCode, const __FlashStringHelper *errorString, uint32_t timeOutMs)
+bool FTPClient::waitFor(const int16_t respCode, const String &errorString, uint32_t timeOutMs)
 {
   // initalize waiting
   if (!aTimeout.canExpire())

--- a/FTPClient.h
+++ b/FTPClient.h
@@ -110,7 +110,7 @@ protected:
 
 	int8_t controlConnect(); // connects to ServerInfo, returns -1: no connection possible, +1: connection established
 
-	bool waitFor(const int16_t respCode, const __FlashStringHelper *errorString = nullptr, uint32_t timeOut = 10000);
+	bool waitFor(const int16_t respCode, const String &errorString = (const char*)NULL, uint32_t timeOut = 10000);
 };
 
 #endif // FTP_CLIENT_H


### PR DESCRIPTION
`__FlashStringHelper` class is abstract from now on, so use `String&` instead